### PR TITLE
plugins.buffer: do not ignore `buffer:false` on request level

### DIFF
--- a/lib/plugins/buffer.js
+++ b/lib/plugins/buffer.js
@@ -21,7 +21,8 @@ BufferPlugin.prototype._setup = function() {
 
   this._rail.on('plugin-response', function(call, options, response) {
     // HEAD responses are buffered too, acting as stream terminator
-    if (self.default || options.buffer && options.buffer !== false) {
+    if (self.default && options.buffer !== false ||
+        !self.default && options.buffer === true) {
       self.intercept(call);
     }
   });

--- a/test/test-http-buffer.js
+++ b/test/test-http-buffer.js
@@ -50,6 +50,37 @@ suite('http:buffer', function() {
   });
 
 
+  test('call w/ buffer=false (request)', function(done) {
+    onrequest = function(request, response) {
+      response.end('pong');
+    };
+
+    rail.call({
+      proto: 'http',
+      port: common.port,
+      buffer: false
+    }, function(response) {
+      assert.strictEqual(response.statusCode, 200);
+
+      assert(!response.buffer);
+      assert(response instanceof http.IncomingMessage);
+
+      var data = [];
+      response.on('readable', function() {
+        data.push(new Buffer(response.read()));
+      });
+
+      response.on('end', function() {
+        var data_ = Buffer.concat(data);
+        assert.strictEqual(data_.length, 4);
+        assert.strictEqual(data_.toString(), 'pong');
+        done();
+      });
+
+    }).end();
+  });
+
+
   suiteTeardown(function(done) {
     server.close(done);
   });


### PR DESCRIPTION
Previously, the "buffer: false" setting was ignored on request level when "buffer" was defaulted to true.
I also added a test which returns the response object as expected.