### PR TITLE
plugins.buffer: fix test for maximum length && add ability to reattac…

### DIFF
--- a/doc/plugins.markdown
+++ b/doc/plugins.markdown
@@ -19,7 +19,7 @@ When the body is empty its value is `null`, otherwise a `Buffer`.
   - `{boolean} default` Enable buffering for all requests, defaults to `false`
   - `{number} max` The maximum buffer size, defaults to `134217728` (128 MiB)
 
-_Note_: When the maximum buffer size is reached, a _bailout_ is performed putting all buffered data back into the response stream and emitting the response.
+_Note_: When the maximum buffer size is reached, a _bailout_ is performed putting all buffered data back into the response stream and emitting the response. Accordingly, the response object will receive the property `bailout` set to `true` as a state indicator.
 
 **request options**
 

--- a/lib/plugins/buffer.js
+++ b/lib/plugins/buffer.js
@@ -23,7 +23,7 @@ BufferPlugin.prototype._setup = function() {
     // HEAD responses are buffered too, acting as stream terminator
     if (self.default && options.buffer !== false ||
         !self.default && options.buffer === true) {
-      self.intercept(call);
+      self.intercept(call, options, response);
     }
   });
 
@@ -39,6 +39,7 @@ BufferPlugin.prototype.intercept = function(call) {
 
 
 BufferPlugin.prototype._interceptResponse = function(call, options, response) {
+  var self = this;
   var length = 0;
   var buffer = [];
 
@@ -51,8 +52,8 @@ BufferPlugin.prototype._interceptResponse = function(call, options, response) {
       buffer.push(data);
 
       // bailout
-      //   aka. stuffing everything back into the readable stream
-      if (length > this.max) {
+      // aka. stuffing everything back into the readable stream
+      if (length > self.max) {
         call.emit('warn', 'buffer', 'bailout', 'max length exceeded');
 
         response.removeListener('readable', onreadable);
@@ -62,6 +63,23 @@ BufferPlugin.prototype._interceptResponse = function(call, options, response) {
           response.unshift(buffer.pop());
         } while (buffer.length);
 
+        /** ************** Note ***************
+         * Once the stream.Readable was consumed and even though it was unshifted,
+         * the following ReadableState states remain `true` after the unshift call:
+         *
+         * response._readableState.reading
+         * response._readableState.calledRead
+         * response._readableState.emittedReadable
+         * response._readableState.readableListening
+         *
+         * Resetting `readableListening` will enable re-attaching listeners for:
+         * - nodejs: v0.10.x, v0.12.x
+         * - iojs: v2.5.x
+         */
+        response._readableState.readableListening = false;
+
+        // indicator for stream consumer
+        response.bailout = true;
         call.__emit('response', response);
       }
     }


### PR DESCRIPTION
…h listeners

test: add a test for `max length exceeded`

The integrated fix works for all current releases of nodejs & iojs